### PR TITLE
Feature/ontology templates override

### DIFF
--- a/apis/settings/base.py
+++ b/apis/settings/base.py
@@ -11,9 +11,9 @@ https://docs.djangoproject.com/en/1.11/ref/settings/
 """
 
 import os
-from typing import Dict, Any
+from typing import Any, Dict
 
-SECRET_KEY = 'a+nkut46lzzg_=ul)zrs29$u_6^*)2by2mjmwn)tqlgw)_at&l'
+SECRET_KEY = "a+nkut46lzzg_=ul)zrs29$u_6^*)2by2mjmwn)tqlgw)_at&l"
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(
@@ -89,7 +89,7 @@ INSTALLED_APPS = [
     "charts",
     "infos",
     "csvexport",
-    "apis_ontology"
+    "apis_ontology",
 ]
 
 USE_X_FORWARDED_HOST = True
@@ -106,11 +106,25 @@ SPECTACULAR_SETTINGS: Dict[str, Any] = {
 }
 
 
-CSP_DEFAULT_SRC = ("'self'", "'unsafe-inline'", 'cdnjs.cloudflare.com', 'cdn.jsdelivr.net', 'fonts.googleapis.com', 
-                    'ajax.googleapis.com', 'cdn.rawgit.com', "*.acdh.oeaw.ac.at", "unpkg.com", "fonts.gstatic.com", 
-                    "cdn.datatables.net", "code.highcharts.com", "*.acdh-dev.oeaw.ac.at", "*.acdh.oeaw.ac.at",
-                    "openstreetmap.org", "*.openstreetmap.org")
-CSP_FRAME_SRC = ('sennierer.github.io',)
+CSP_DEFAULT_SRC = (
+    "'self'",
+    "'unsafe-inline'",
+    "cdnjs.cloudflare.com",
+    "cdn.jsdelivr.net",
+    "fonts.googleapis.com",
+    "ajax.googleapis.com",
+    "cdn.rawgit.com",
+    "*.acdh.oeaw.ac.at",
+    "unpkg.com",
+    "fonts.gstatic.com",
+    "cdn.datatables.net",
+    "code.highcharts.com",
+    "*.acdh-dev.oeaw.ac.at",
+    "*.acdh.oeaw.ac.at",
+    "openstreetmap.org",
+    "*.openstreetmap.org",
+)
+CSP_FRAME_SRC = ("sennierer.github.io",)
 
 CRISPY_TEMPLATE_PACK = "bootstrap3"
 
@@ -130,7 +144,7 @@ REST_FRAMEWORK = {
     ),
     "DEFAULT_FILTER_BACKENDS": (
         "django_filters.rest_framework.DjangoFilterBackend",
-        #"drf_spectacular.contrib.django_filters.DjangoFilterBackend",
+        # "drf_spectacular.contrib.django_filters.DjangoFilterBackend",
     ),
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
 }
@@ -280,7 +294,6 @@ APIS_RELATIONS_FILTER_EXCLUDE = [
 ]
 
 
-
 APIS_RELATIONS = {
     "list_filters": [("relation_type",)],
     "search": ["relation_type__name"],
@@ -293,9 +306,13 @@ APIS_RELATIONS = {
             "related_person__first_name",
             "related_place__name",
         ],
-       # "include": ["related_place"], use include statement to set a list of filters
+        # "include": ["related_place"], use include statement to set a list of filters
         "list_filters": [("relation_type",), ("related_person",), ("related_place",)],
-        "exclude": ["related_person__first_name", "related_place__lng", "related_place__lat"]
+        "exclude": [
+            "related_person__first_name",
+            "related_place__lng",
+            "related_place__lat",
+        ],
     },
     "PersonInstitution": {
         "labels": ["related_person", "related_institution", "relation_type"],
@@ -309,8 +326,8 @@ APIS_RELATIONS = {
             ("relation_type",),
             ("related_person",),
             ("related_institution",),
-            ],
-        "exclude": ["related_person__first_name"]
+        ],
+        "exclude": ["related_person__first_name"],
     },
     "PersonEvent": {
         "labels": ["related_person", "related_event", "relation_type"],
@@ -321,7 +338,7 @@ APIS_RELATIONS = {
             "related_event__name",
         ],
         "list_filters": [("relation_type",), ("related_person",), ("related_event",)],
-        "exclude": ["related_person__first_name"]
+        "exclude": ["related_person__first_name"],
     },
     "PersonWork": {
         "labels": ["related_person", "related_work", "relation_type"],
@@ -332,7 +349,7 @@ APIS_RELATIONS = {
             "related_work__name",
         ],
         "list_filters": [("relation_type",), ("related_person",), ("related_work",)],
-        "exclude": ["related_person__first_name"]
+        "exclude": ["related_person__first_name"],
     },
     "PersonPerson": {
         "labels": ["related_personA", "related_personB", "relation_type"],
@@ -348,7 +365,7 @@ APIS_RELATIONS = {
             ("related_personA",),
             ("related_personB",),
         ],
-        "exclude": ["related_person__first_name"]
+        "exclude": ["related_person__first_name"],
     },
     "InstitutionPlace": {
         "labels": ["related_institution", "related_place", "relation_type"],
@@ -362,7 +379,7 @@ APIS_RELATIONS = {
             ("related_institution",),
             ("related_place",),
         ],
-        "exclude": ["related_place__lat", "related_place__lng"]
+        "exclude": ["related_place__lat", "related_place__lng"],
     },
     "InstitutionWork": {
         "labels": ["related_institution", "related_work", "relation_type"],
@@ -407,13 +424,13 @@ APIS_RELATIONS = {
         "labels": ["related_work", "related_place", "relation_type"],
         "search": ["relation_type__name", "related_place__name", "related_work__name"],
         "list_filters": [("relation_type",), ("related_place",), ("related_work",)],
-        "exclude": ["related_place__lat", "related_place__lng"]
+        "exclude": ["related_place__lat", "related_place__lng"],
     },
     "PlaceEvent": {
         "labels": ["related_event", "related_place", "relation_type"],
         "search": ["relation_type__name", "related_place__name", "related_event__name"],
         "list_filters": [("relation_type",), ("related_place",), ("related_event",)],
-        "exclude": ["related_place__lat", "related_place__lng"]
+        "exclude": ["related_place__lat", "related_place__lng"],
     },
     "PlacePlace": {
         "labels": ["related_placeA", "related_placeB", "relation_type"],
@@ -423,7 +440,7 @@ APIS_RELATIONS = {
             "related_placeB__name",
         ],
         "list_filters": [("relation_type",), ("related_placeA",), ("related_placeB",)],
-        "exclude": ["related_place__lat", "related_place__lng"]
+        "exclude": ["related_place__lat", "related_place__lng"],
     },
     "EventWork": {
         "labels": ["related_event", "related_work", "relation_type"],

--- a/apis/settings/base.py
+++ b/apis/settings/base.py
@@ -174,7 +174,7 @@ ROOT_URLCONF = "apis.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
+        "DIRS": [os.path.join(BASE_DIR, "apis_ontology", "templates")],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [


### PR DESCRIPTION
Added apis_ontology/templates directory to the base.py settings file

Example: The template 
apis-core/apis_core/apis_entities/templates/_apis_entities/detail_views/entity_detail_generic.html_
 
can be overridden in apis_ontology by creating the following file. 
apis_ontology/templates/_apis_entities/detail_views/entity_detail_generic.html_

**Related issues and PRs**
Resolves issue:
- #3 (partially)

**Checklist (Replace the space in square brackets with a lowercase x for all that apply)**
- [x] My changes don't generate new warnings or errors
- [x] My changes follow the project's code formatting rules and style guidelines
- [ ] I have commented my code with Docstrings and code comments, particularly complex, unusual or hard-to-read code
- [ ] I have updated the project documentation to reflect the changes I introduce
- [ ] I have added new unit tests or updated existing ones to demonstrate my changes works
