### PR TITLE
Default DJANGO_SETTINGS_MODULE to ontologies local_settings

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -5,7 +5,11 @@ import sys
 
 if __name__ == "__main__":
     if os.getenv("DJANGO_SETTINGS_MODULE") is None:
-        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "apis.settings.base")
+        # check for local_settings.py for APIS Ontologies apps
+        if os.path.isdir("apis_ontology") and os.path.isfile("apis_ontology/settings/local_settings.py"):
+            os.environ.setdefault("DJANGO_SETTINGS_MODULE", "apis_ontology.settings.local_settings")
+        else:
+            os.environ.setdefault("DJANGO_SETTINGS_MODULE", "apis.settings.base")
     try:
         from django.core.management import execute_from_command_line
     except ImportError:

--- a/manage.py
+++ b/manage.py
@@ -22,7 +22,6 @@ if __name__ == "__main__":
             )
         raise
 
-
     # TODO : Check at some time if the bug in dal_select2 has been fixed, and if so, remove this function here
     def work_around_dal_select2_bug():
         """
@@ -35,32 +34,40 @@ if __name__ == "__main__":
 
         import dal_select2
 
-        file_to_fix = dal_select2.__file__.replace("/__init__.py", "/static/autocomplete_light/select2.js")
-        min_file_to_fix = dal_select2.__file__.replace("/__init__.py", "/static/autocomplete_light/select2.min.js") 
-        
+        file_to_fix = dal_select2.__file__.replace(
+            "/__init__.py", "/static/autocomplete_light/select2.js"
+        )
+        min_file_to_fix = dal_select2.__file__.replace(
+            "/__init__.py", "/static/autocomplete_light/select2.min.js"
+        )
+
         try:
             with open(file_to_fix, "r") as f:
                 lines = f.readlines()
 
             for i, line in enumerate(lines):
 
-                if \
-                        line == "                processResults: function (data, page) {\n" and \
-                        lines[i+1] == "                    if ($element.attr('data-tags')) {\n" and \
-                        lines[i+2] == "                        $.each(data.results, function (index, value) {\n" and \
-                        lines[i+3] == "                            value.id = value.text;\n":
+                if (
+                    line == "                processResults: function (data, page) {\n"
+                    and lines[i + 1]
+                    == "                    if ($element.attr('data-tags')) {\n"
+                    and lines[i + 2]
+                    == "                        $.each(data.results, function (index, value) {\n"
+                    and lines[i + 3]
+                    == "                            value.id = value.text;\n"
+                ):
 
-                    lines[i+3] = "                            value.id = value.id;\n"
+                    lines[i + 3] = "                            value.id = value.id;\n"
 
             with open(file_to_fix, "w") as f:
                 f.write("".join(lines))
 
         except FileNotFoundError:
             raise Exception(
-                "Could not find select2.js file to inject bug workaround into.\n" +
-                "Maybe the dal_select library has changed and this workaround is not necessary anymore?"
+                "Could not find select2.js file to inject bug workaround into.\n"
+                + "Maybe the dal_select library has changed and this workaround is not necessary anymore?"
             )
-        
+
         try:
             with open(min_file_to_fix, "r") as f:
                 f_out = f.read().replace("e.id=e.text", "e.id=e.id")
@@ -68,11 +75,10 @@ if __name__ == "__main__":
                 f.write(f_out)
         except FileNotFoundError:
             raise Exception(
-                "Could not find select2.min.js file to inject bug workaround into.\n" +
-                "Maybe the dal_select library has changed and this workaround is not necessary anymore?"
+                "Could not find select2.min.js file to inject bug workaround into.\n"
+                + "Maybe the dal_select library has changed and this workaround is not necessary anymore?"
             )
 
     work_around_dal_select2_bug()
-
 
     execute_from_command_line(sys.argv)


### PR DESCRIPTION
The current default for when no `DJANGO_SETTINGS_MODULE` env variable is detected is to set it to `apis.settings.base`, which doesn't work (or make sense) for Ontologies apps.

This PR adapts `manage.py` so it first checks for the existence of `apis_ontology/settings/local_settings.py` to use that to populate `DJANGO_SETTINGS_MODULE`.

This change makes it unnecessary to always explicitly reference the default settings file for local development with `--settings=apis_ontology.settings.local_settings`. (Though it continues to be possible, of course, to manually point to a specific settings file this way, which then overrides the default.)

**Checklist (Replace the space in square brackets with a lowercase x for all that apply)**
- [x] My changes don't generate new warnings or errors
- [x] My changes follow the project's code formatting rules and style guidelines
- [x] I have commented my code with Docstrings and code comments, particularly complex, unusual or hard-to-read code
- [ ] I have updated the project documentation to reflect the changes I introduce
- [ ] I have added new unit tests or updated existing ones to demonstrate my changes works
