### PR TITLE
Fix: override default secret key with environment variable

### DIFF
--- a/apis/settings/base.py
+++ b/apis/settings/base.py
@@ -13,7 +13,10 @@ https://docs.djangoproject.com/en/1.11/ref/settings/
 import os
 from typing import Any, Dict
 
-SECRET_KEY = "a+nkut46lzzg_=ul)zrs29$u_6^*)2by2mjmwn)tqlgw)_at&l"
+# We fall back to a DEFAULT_SECRET_KEY, but you should
+# override this using an environment variable!
+DEFAULT_SECRET_KEY = "a+nkut46lzzg_=ul)zrs29$u_6^*)2by2mjmwn)tqlgw)_at&l"
+SECRET_KEY = os.environ.get('SECRET_KEY', DEFAULT_SECRET_KEY)
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(


### PR DESCRIPTION
This commit introduces a new environment variable SECRET_KEY that overrides the
default Django SECRET_KEY that is set in apis.settings.base
