### PR TITLE
Feat: introduce global sentry configuration

### DIFF
--- a/apis/settings/base.py
+++ b/apis/settings/base.py
@@ -13,6 +13,27 @@ https://docs.djangoproject.com/en/1.11/ref/settings/
 import os
 from typing import Any, Dict
 
+if os.environ.get('SENTRY_DSN'):
+    import sentry_sdk
+    from sentry_sdk.integrations.django import DjangoIntegration
+
+    sentry_sdk.init(
+        dsn=os.environ.get('SENTRY_DSN'),
+        integrations=[
+            DjangoIntegration(),
+        ],
+        environment="production",
+
+        # Set traces_sample_rate to 1.0 to capture 100%
+        # of transactions for performance monitoring.
+        # We recommend adjusting this value in production.
+        traces_sample_rate=1.0,
+
+        # If you wish to associate users to errors (assuming you are using
+        # django.contrib.auth) you may enable sending PII data.
+        send_default_pii=True
+    )
+
 # We fall back to a DEFAULT_SECRET_KEY, but you should
 # override this using an environment variable!
 DEFAULT_SECRET_KEY = "a+nkut46lzzg_=ul)zrs29$u_6^*)2by2mjmwn)tqlgw)_at&l"


### PR DESCRIPTION
Currently all the ontologies use sentry, so it makes sense to move the
configuration to a central place. This also makes it possible to move the
sentry DSN to the environment.
