### PR TITLE
Delete apis_core softlink

### DIFF
--- a/apis_core
+++ b/apis_core
@@ -1,1 +1,0 @@
-apis-core/apis_core


### PR DESCRIPTION
This link is most likely not needed anywhere, therefore we can remove it to
reduce complexity.

Closes: #25
