### PR TITLE
Add CREATE_RELATIONSHIPS environment variable

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -12,6 +12,7 @@ pwd
 echo $APIS_RDF_ONTOLOGY
 python manage.py migrate
 python manage.py collectstatic --noinput
+[[ $CREATE_RELATIONSHIPS == "True" ]] && python manage.py create_relationships
 #ls /var/solr_new/paas_solr
 #python manage.py build_solr_schema --configure-directory /var/solr_new/paas_solr/conf --reload-core default
 #gunicorn apis.wsgi --timeout 120 --workers=3 --threads=3 --worker-connections=1000


### PR DESCRIPTION
This environment variable can be used to control if the `create_relationships`
management command should be run.

Closes #27
