### PR TITLE
Run the build after a submodule update workflow finished

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+  workflow_run:
+    workflows: ["Update submodules"]
+    types:
+      - completed
 
 # on:
 #   workflow_run:


### PR DESCRIPTION
Use the workflow_run event to start this workflow when the "Update
submodules" workflow is completed.
