### PR TITLE
Fix menu toggler icon on small screens

### DIFF
--- a/webpage/static/webpage/fundament/images/burger.svg
+++ b/webpage/static/webpage/fundament/images/burger.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="30px" height="30px" viewBox="0 0 30 30" enable-background="new 0 0 30 30" xml:space="preserve">
+	<g id="Layer_1">
+		<path fill="rgba(0, 0, 0, 0)" stroke="rgba(0, 0, 0, 0.7)" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" d="M4 7h22M4 15h22M4 23h22"/>
+	</g>
+</svg>

--- a/webpage/templates/webpage/base.html
+++ b/webpage/templates/webpage/base.html
@@ -84,7 +84,7 @@
 
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavDropdown"
                 aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
-          <span class="navbar-toggler-icon"/>
+          <span class="navbar-toggler-icon" style="background-image: url('{% static 'webpage/fundament/images/burger.svg' %}')!important;"></span>
         </button>
 
         <!-- Start main menu -->


### PR DESCRIPTION
**Describe your changes**
Adds SVG file for "burger" icon to access the main menu on mobile devices + overrides CSS for `navbar-toggler-icon` in `webpage/base.html` as a temporary workaround.

**Additional context**
This issue is one with `fundament.min.css` (or Bootstrap, more generally) and has also been reported in the [fundament repo](https://github.com/acdh-oeaw/fundament/issues/20) to raise awareness about a longer-term solution needing to be found.

**Related issues and PRs**
Resolves issue:
- https://github.com/acdh-oeaw/apis-webpage/issues/7


**Checklist (Replace the space in square brackets with a lowercase x for all that apply)**
- [x] My changes don't generate new warnings or errors
- [x] My changes follow the project's code formatting rules and style guidelines