### PR TITLE
chore: remove sicprod from deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,17 +117,3 @@ jobs:
         POSTGRES_ENABLED: ${{ needs.setup_workflow_env.outputs.POSTGRES_ENABLED == 'true'}}
         environment: "Tibschol Development"
         default_port: "${{ needs.setup_workflow_env.outputs.default_port}}"
-
-  deploy_sicprod:
-      needs: [setup_workflow_env, build_and_push_to_registry]
-      uses: acdh-oeaw/gl-autodevops-minimal-port/.github/workflows/deploy-cluster-2.yml@main
-      secrets: inherit
-      with:
-        DOCKER_TAG: ${{ needs.setup_workflow_env.outputs.registry_root }}${{ needs.setup_workflow_env.outputs.image_tagged }}/${{ github.ref_name }}
-        APP_NAME: sicprod-dev
-        APP_ROOT: ${{ needs.setup_workflow_env.outputs.APP_ROOT }}
-        SERVICE_ID: "20870"
-        PUBLIC_URL: "https://sicprod.acdh-dev.oeaw.ac.at"
-        POSTGRES_ENABLED: ${{ needs.setup_workflow_env.outputs.POSTGRES_ENABLED == 'true'}}
-        environment: "SiCProD Development"
-        default_port: "${{ needs.setup_workflow_env.outputs.default_port}}"


### PR DESCRIPTION
sicprod is now deployed from acdh-oeaw/apis-instance-sicprod-dev
